### PR TITLE
Fix network build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,5 +18,5 @@ add_executable(HydraMMORPG ${SOURCES})
 
 # Link DirectX libraries
 if (WIN32)
-    target_link_libraries(HydraMMORPG d3d12 dxgi dxguid)
+    target_link_libraries(HydraMMORPG d3d12 dxgi dxguid ws2_32)
 endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,5 @@
+#define UNICODE
+#include <winsock2.h> // must precede windows.h on Windows
 #include <windows.h>
 #include <wrl.h>
 #include <d3d12.h>
@@ -55,6 +57,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow) {
 
     hydra::UIManager ui;
     ui.initialize();
+    hydra::NetworkClient net;
     hydra::TaskManager tasks;
 
     // Simple game state setup
@@ -69,7 +72,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow) {
     hydra::World world;
     world.addPlayer(player);
 
-    hydra::NetworkClient net;
     tasks.startTask([&net](){
         net.connect("127.0.0.1", 7000); // placeholder connection
     });


### PR DESCRIPTION
## Summary
- include winsock2 before windows headers and enable UNICODE
- link against ws2_32 for WinSock
- verified build succeeds with mingw cross compiler

## Testing
- `apt-get install -y mingw-w64`
- `cmake -S . -B build -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_SYSTEM_NAME=Windows`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68864bd2242c8331ba5ac8237a3bb3c3